### PR TITLE
Updated for incremental builds and multiple environments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,22 +8,21 @@ ensure_micromamba(MICROMAMBA_BIN)
 
 # Configure an environment directly
 micromamba_environment(
-NAME environment
-CHANNELS
+NAME environment		# Name of the environment
+CHANNELS				# Channels to pull packages from
 	conda-forge
 	# robostack
-DEPENDENCIES
+DEPENDENCIES			# List of dependencies to install
 	spdlog
 )
 
-# Or configure it with a config file
+# Or configure it with a spec file
 micromamba_environment(
-	NAME configenv
-	SPEC_FILE config.yaml
-	RUN_CMD CONFIGENV_RUN
-	ENV_PATH CONFIGENV_PATH
-	NO_PREFIX_PATH
-	VERBOSE 3
+	NAME configenv			# Name of the environment
+	SPEC_FILE config.yaml   # Spec file to create the environment with
+	RUN_CMD CONFIGENV_RUN   # On return - ${CONFIGENV_RUN} will be a command that runs commands within the environment
+	ENV_PATH CONFIGENV_PATH # On return - ${CONFIGENV_PATH} will be the path to the environment
+	NO_PREFIX_PATH			# Do not add this environment to the CMAKE_PREFIX_PATH
 )
 
 # Now you can run commands within the micromamba environment at configuration or build time

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@ include(micromamba.cmake)
 
 ensure_micromamba(MICROMAMBA_BIN)
 
+# Configure an environment directly
 micromamba_environment(
+NAME environment
 CHANNELS
 	conda-forge
 	# robostack
@@ -14,8 +16,24 @@ DEPENDENCIES
 	spdlog
 )
 
+# Or configure it with a config file
+micromamba_environment(
+	NAME configenv
+	SPEC_FILE config.yaml
+	RUN_CMD CONFIGENV_RUN
+	ENV_PATH CONFIGENV_PATH
+	NO_PREFIX_PATH
+	VERBOSE 3
+)
+
+# Now you can run commands within the micromamba environment at configuration or build time
+execute_process(
+	COMMAND ${CONFIGENV_RUN} python -c "import sys; print('Running this under mamba: ', sys.executable)"
+)
+
 set(CMAKE_CXX_STANDARD 17)
 find_package(spdlog REQUIRED)
 
+
 add_executable(test src/test.cpp)
-target_link_libraries(test spdlog)
+target_link_libraries(test spdlog::spdlog)

--- a/README.md
+++ b/README.md
@@ -7,3 +7,29 @@ Create mamba environments directly in your CMake.
 The scripts here are meant to check if micromamba is available on the system. If not, it will be downloaded.
 
 Then, micromamba is used to install the dependencies.
+
+## Usage:
+
+```
+micromamba_environment(
+    [NAME name]
+    [SPEC_FILE [files...]]
+    [CHANNELS [channels...]]
+    [DEPENDENCIES [dependencies...]]
+    [VERBOSE verbosity (0,1,2,3)]
+    [RUN_CMD var]
+    [ENV_PATH var]
+    [NO_PREFIX_PATH]
+    [NO_DEPENDS]
+)
+```
+
+* `NAME` - Name of the environment to create. Defaults to `environment`
+* `SPEC_FILE` - A spec file specifying what should go in the environment - see mamba documentation for details. This file will also become a configuration dependency, so that changing it will cause cmake to reconfigure (and update the environment) - unless `NO_DEPENDS` is specified (see below)
+* `CHANNELS` - A list of channels to search for packages
+* `DEPENDENCIES` - A directly specified list of dependencies
+* `VERBOSE` - Verbosity level (0,1,2,3)
+* `RUN_CMD` - Variable that will be populated with a command line that can be used to run commands within the environment (essentially it will contain `micromamba run`, with the environment fully specified). It can then be used like `execute_command(COMMAND ${RUN_CMD_OUT} python foo.py)`
+* `ENV_PATH` - Full path to the environment that was created. This will be within the build folder.
+* `NO_PREFIX_PATH` - Do not add the new environment to any cmake search paths. I.e. `find_package` will not search within this environment for packages.
+* `NO_DEPENDS` - Do not add a configuration dependency on the spec file. Users will need to explicitly re-run cmake to configure the project after a spec file change.

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+dependencies:
+  - python >= 3.6
+  - requests

--- a/micromamba.cmake
+++ b/micromamba.cmake
@@ -1,46 +1,105 @@
 function(mamba_get_native_arch MAMBA_NATIVE_ARCH)
-  if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
-      set (${MAMBA_NATIVE_ARCH} "osx-arm64" PARENT_SCOPE)
+  if (CMAKE_HOST_APPLE)
+    if(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "arm")
+      set (ARCH "osx-arm64")
     else()
-      set (${MAMBA_NATIVE_ARCH} "osx-64" PARENT_SCOPE)
+      set (ARCH "osx-64")
     endif()
+  elseif(CMAKE_HOST_UNIX)
+    if(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "x64|x86_64")
+      set (ARCH "linux-64")
+    elseif(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "aarch64|arm64")
+      set (ARCH "linux-aarch64")
+    endif()
+  # elseif(CMAKE_HOST_WIN32)
+  #   if(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "ARM64")
+  #     set (${MAMBA_NATIVE_ARCH} "win-64")
+  #   endif()
   endif()
+
+  if(DEFINED ARCH)
+    set(${MAMBA_NATIVE_ARCH} ${ARCH} PARENT_SCOPE)
+  endif()
+
 endfunction()
 
+# Ensures the micromamba binary is available
+# Arguments:
+#  MICROMAMBA_BIN: Name of the variable to store the path to the micromamba binary
 function(ensure_micromamba MICROMAMBA_BIN)
-	message("Hello micromamba")
+  set(MICROMAMBA_PATH ${CMAKE_BINARY_DIR}/micromamba_bin)
+
   find_program(_MICROMAMBA_BIN micromamba
-    PATHS micromamba_bin/bin
+    PATHS ${MICROMAMBA_PATH}/bin
   )
-  message("Found micromamba at ${_MICROMAMBA_BIN}")
   if (_MICROMAMBA_BIN)
     message("Found micromamba at ${_MICROMAMBA_BIN}")
   else()
     message("Downloading micromamba")
     mamba_get_native_arch(MAMBA_NATIVE_ARCH)
     message("Native arch: ${MAMBA_NATIVE_ARCH}")
-    file(MAKE_DIRECTORY "micromamba_bin")
-    file(DOWNLOAD "https://micro.mamba.pm/api/micromamba/${MAMBA_NATIVE_ARCH}/latest" micromamba_bin/micromamba.tar.bz2)
+    file(MAKE_DIRECTORY ${MICROMAMBA_PATH}/bin)
+    file(DOWNLOAD "https://micro.mamba.pm/api/micromamba/${MAMBA_NATIVE_ARCH}/latest" ${MICROMAMBA_PATH}/micromamba.tar.bz2)
     execute_process(COMMAND
       ${CMAKE_COMMAND} -E
-      tar xvzf -C micromamba_bin/bin "micromamba_bin/micromamba.tar.bz2" -- "bin/micromamba")
+      tar xvzf ${MICROMAMBA_PATH}/micromamba.tar.bz2 -- "bin/micromamba"
+      WORKING_DIRECTORY ${MICROMAMBA_PATH} )
   endif()
-  set (MICROMAMBA_BIN ${_MICROMAMBA_BIN} PARENT_SCOPE)
+  set (${MICROMAMBA_BIN} ${_MICROMAMBA_BIN} PARENT_SCOPE)
 endfunction()
 
-function(micromamba_environment)
-  message("Installing dependencies from channels:")
+# Checks if a micromamba environment exists
+# Arguments:
+#   ENV_NAME: Name of the environment
+#   OUTVAR: Name of the variable to store the result
+function(check_micromamba_environment ENV_NAME OUTVAR)
+  set(ENV_PATH ${CMAKE_BINARY_DIR}/environments/${ENV_NAME})
+  if (EXISTS "${ENV_PATH}/conda-meta/history" )
+    set(${OUTVAR} TRUE PARENT_SCOPE)
+  else()
+    unset(${OUTVAR} PARENT_SCOPE)
+  endif()
+endfunction()
+  
 
+# Create a micromamba environment
+#
+# Arguments:
+#   NAME: Name of the environment
+#   VERBOSE: Verbosity level (0, 1, 2, 3)
+#   RUN_CMD: Name of the variable to store the command for running command within the environment
+#   ENV_PATH: Name of the variable to store the path to the environment
+#   CHANNELS: List of channels to use
+#   DEPENDENCIES: List of dependencies to install
+#   SPEC_FILE: List of spec files to use
+#   NO_PREFIX_PATH: Do not add the environment path to the list of prefix paths
+#   NO_DEPENDS: Do not add the spec files to the configuration dependencies
+#
+function(micromamba_environment)
     cmake_parse_arguments(
         PARSED_ARGS # prefix of output variables
-        "" # list of names of the boolean arguments (only defined ones will be true)
-        "" # list of names of mono-valued arguments
-        "CHANNELS;DEPENDENCIES" # list of names of multi-valued arguments (output variables are lists)
+        "NO_PREFIX_PATH;NO_DEPENDS" # list of names of the boolean arguments (only defined ones will be true)
+        "NAME;VERBOSE;RUN_CMD;ENV_PATH" # list of names of mono-valued arguments
+        "CHANNELS;DEPENDENCIES;SPEC_FILE" # list of names of multi-valued arguments (output variables are lists)
         ${ARGN} # arguments of the function to parse, here we take the all original ones
     )
 
-  ensure_micromamba(MICROMAMBA_BIN)
+  # Parse the arguments
+  set(ENV_NAME "environment")
+  if(DEFINED PARSED_ARGS_NAME)
+    set(ENV_NAME ${PARSED_ARGS_NAME})
+  endif()
+
+  set(VERBOSE_FLAG "--quiet")
+  if(PARSED_ARGS_VERBOSE EQUAL 0)
+    set(VERBOSE_FLAG "--quiet")
+  elseif(PARSED_ARGS_VERBOSE EQUAL 1)
+    set(VERBOSE_FLAG "")
+  elseif(PARSED_ARGS_VERBOSE EQUAL 2)
+    set(VERBOSE_FLAG "--verbose")
+  elseif(PARSED_ARGS_VERBOSE EQUAL 3)
+    set(VERBOSE_FLAG "-vv")
+  endif()
 
   set (CHANNEL_ARG "")
   foreach(C ${PARSED_ARGS_CHANNELS})
@@ -48,13 +107,56 @@ function(micromamba_environment)
     list(APPEND CHANNEL_ARG ${C})
   endforeach()
 
-  execute_process(COMMAND echo
-    ${MICROMAMBA_BIN} create -p ${CMAKE_BINARY_DIR}/environment ${CHANNEL_ARG} ${PARSED_ARGS_DEPENDENCIES} -v --yes --quiet)
-  execute_process(COMMAND
-    ${MICROMAMBA_BIN} create -p ${CMAKE_BINARY_DIR}/environment ${CHANNEL_ARG} ${PARSED_ARGS_DEPENDENCIES} --yes --quiet)
+  set (FILE_ARG "")
+  foreach(F ${PARSED_ARGS_SPEC_FILE})
+    list(APPEND FILE_ARG "--file")
+    list(APPEND FILE_ARG ${F})
+  endforeach()
+  
+  set(ENV_PATH ${CMAKE_BINARY_DIR}/environments/${ENV_NAME})
 
-  SET(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/environment" CACHE INTERNAL "CMAKE_INSTALL_PREFIX")
+  ensure_micromamba(MICROMAMBA_BIN)
 
-  # set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/environment PARENT_SCOPE)
-  set(CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/environment PARENT_SCOPE)
+  check_micromamba_environment(${ENV_NAME} ENV_EXISTS)
+
+  if(ENV_EXISTS)
+    message("Updating micromamba environment '${ENV_NAME}' at ${ENV_PATH}")
+    execute_process(COMMAND echo
+    ${MICROMAMBA_BIN} install -p ${ENV_PATH} ${CHANNEL_ARG} ${FILE_ARG} ${PARSED_ARGS_DEPENDENCIES} --yes ${VERBOSE_FLAG}
+    )
+    execute_process(COMMAND
+    ${MICROMAMBA_BIN} install -p ${ENV_PATH} ${CHANNEL_ARG} ${FILE_ARG} ${PARSED_ARGS_DEPENDENCIES} --yes ${VERBOSE_FLAG}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+  else()
+    message("Creating micromamba environment '${ENV_NAME}' at ${ENV_PATH} - this may take a while")
+    execute_process(COMMAND echo
+      ${MICROMAMBA_BIN} create -p ${ENV_PATH} ${CHANNEL_ARG} ${FILE_ARG} ${PARSED_ARGS_DEPENDENCIES} --yes ${VERBOSE_FLAG})
+    execute_process(COMMAND
+      ${MICROMAMBA_BIN} create -p ${ENV_PATH} ${CHANNEL_ARG} ${FILE_ARG} ${PARSED_ARGS_DEPENDENCIES} --yes ${VERBOSE_FLAG}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      )
+  endif()
+  
+  # Add the spec files to the list of files to watch for changes
+  if(NOT DEFINED PARSED_ARGS_NO_DEPENDS)
+    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${PARSED_ARGS_SPEC_FILE})
+  endif()
+
+  # Add the environment path to the list of prefix paths
+  if(NOT PARSED_ARGS_NO_PREFIX_PATH)
+    set(CMAKE_INSTALL_PREFIX ${ENV_PATH} CACHE INTERNAL "CMAKE_INSTALL_PREFIX")
+    list(PREPEND CMAKE_PREFIX_PATH ${ENV_PATH})
+    set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} PARENT_SCOPE)
+  endif()
+
+  if(DEFINED PARSED_ARGS_RUN_CMD)
+    list(APPEND RUN_CMD ${MICROMAMBA_BIN} -p ${ENV_PATH} run )
+    set(${PARSED_ARGS_RUN_CMD} ${RUN_CMD} PARENT_SCOPE)
+  endif()
+
+  if(DEFINED PARSED_ARGS_ENV_PATH)
+    set(${PARSED_ARGS_ENV_PATH} ${ENV_PATH} PARENT_SCOPE)
+  endif()
+
 endfunction()

--- a/micromamba.cmake
+++ b/micromamba.cmake
@@ -44,6 +44,10 @@ function(ensure_micromamba MICROMAMBA_BIN)
       ${CMAKE_COMMAND} -E
       tar xvzf ${MICROMAMBA_PATH}/micromamba.tar.bz2 -- "bin/micromamba"
       WORKING_DIRECTORY ${MICROMAMBA_PATH} )
+      
+    find_program(_MICROMAMBA_BIN micromamba
+      PATHS ${MICROMAMBA_PATH}/bin
+    )
   endif()
   set (${MICROMAMBA_BIN} ${_MICROMAMBA_BIN} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
# Overview

Updated the micromamba.cmake script with some new features:

* Can download linux micromamba binaries
* Doesn't require `tar` to support the `-C` flag (missing on Ubuntu at least)
* Puts all micromamba products (binaries and environments) into the build directory
* Can build an environment from a spec file or files
* Supports multiple micromamba environments
* Incremental updates to existing environments - runs `micromamba create` the first time and `micromamba install` if there is an existing environment
* Spec files will be config dependencies, so modifying a spec file will
 automatically reconfigure the project next time cmake does a build

Note: This also sets up micromamba to install for the _host_ system (i.e. the one doing the compilation). 
If you are doing cross-compilation and need a micromamba environment for the _target_ system, additional modifications to this
 script may be needed.

# Purpose

The reason for these changes is that I wanted to be able to create isolated python environments within a project, and be able to have a simple manifest that listed all the python packages I needed). `micromamba` was a very useful tool but I ran into some missing features for my cmake build like support for Ubuntu, and the ability to create multiple environments (for example separate environments for the main build and building test code)
